### PR TITLE
Enable checks for FreeIPA's firewall settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 helper_status_ok: OK
 helper_status_error: ERROR
+helper_status_skipped: SKIPPED
 helper_report_path: /tmp/report.txt

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,5 +1,7 @@
 ---
 # These tasks apply to all nodes.
+
+# DNS related tasks
 - name: Try to ping ipa-ca
   command: ping -c 3 ipa-ca
   register: ipa_ca_ping_status
@@ -31,3 +33,61 @@
     report_host: '{{ ansible_hostname }}'
     report_reason: '{{ dns_reason }}'
     report_recommendations: '{{ dns_recommendations }}'
+
+# Firewall related tasks
+- name: Firewall validations
+  when: ipa_ca_ping_status.rc == 0
+  block:
+    - name: Check all relevant ports for IdM/FreeIPA are accessible from {{ ansible_hostname }}
+      wait_for:
+        host: ipa-ca
+        port: "{{ item }}"
+        state: started         # Port should be open
+        delay: 0               # No wait before first check (sec)
+        timeout: 3             # Stop checking after timeout (sec)
+      register: port_status
+      ignore_errors: true
+      loop:
+        - 80
+        - 443
+        - 389
+        - 636
+        - 88
+        - 464
+        - 53
+
+    - name: Set facts for ok firewall settings
+      set_fact:
+        firewall_status: '{{ helper_status_ok }}'
+        firewall_reason: "The host {{ ansible_hostname }} can access FreeIPA through all relevant ports"
+        firewall_recommendations: null
+      when: not port_status.failed|bool
+
+    - name: Set facts for issues in firewall settings
+      set_fact:
+        firewall_status: '{{ helper_status_error }}'
+        firewall_reason: "The host {{ ansible_hostname }} could NOT access IdM/FreeIPA on some ports"
+        firewall_recommendations:
+          - "Please make sure that the following ports are open on the IdM/FreeIPA node: {{ firewall_query }}"
+      vars:
+        firewall_query: "{{ port_status.results | json_query('[?failed].item') | join(', ') }}"
+      when: port_status.failed|bool
+
+    - name: debugging firewall recs
+      debug:
+        msg: "Debugging {{ firewall_recommendations }}"
+
+- name: Set facts for skipping firewall checks
+  set_fact:
+    firewall_status: '{{ helper_status_skipped }}'
+    firewall_reason: "skipped {{ ansible_hostname }} firewall checks because DNS wasn't set correctly."
+    firewall_recommendations: null
+  when: ipa_ca_ping_status.rc != 0
+
+- name: Report firwall status
+  import_tasks: reportentry.yml
+  vars:
+    report_status: '{{ firewall_status }}'
+    report_host: '{{ ansible_hostname }}'
+    report_reason: '{{ firewall_reason }}'
+    report_recommendations: '{{ firewall_recommendations }}'


### PR DESCRIPTION
This checks that all the nodes can actually access the relevant
ports for FreeIPA. This is useful for debugging both FreeIPA's
firewall settings, and the nodes' firewall settings too.

This check is skipped if DNS checks failed.