### PR TITLE
Set markers for the report

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -29,6 +29,7 @@
 - name: Report DNS status
   import_tasks: reportentry.yml
   vars:
+    report_check: "DNS check"
     report_status: '{{ dns_status }}'
     report_host: '{{ ansible_hostname }}'
     report_reason: '{{ dns_reason }}'
@@ -87,6 +88,7 @@
 - name: Report firwall status
   import_tasks: reportentry.yml
   vars:
+    report_check: "Firewall check"
     report_status: '{{ firewall_status }}'
     report_host: '{{ ansible_hostname }}'
     report_reason: '{{ firewall_reason }}'

--- a/tasks/reportentry.yml
+++ b/tasks/reportentry.yml
@@ -2,7 +2,7 @@
 - name: Write report entry
   blockinfile:
     create: true
-    marker: ''
+    marker: '* {mark} {{ report_check }} for host {{ report_host }}'
     path: '{{ helper_report_path }}'
     content: "{{ lookup('template', 'templates/report-template-txt.j2') }}"
   delegate_to: localhost

--- a/templates/report-template-txt.j2
+++ b/templates/report-template-txt.j2
@@ -1,4 +1,4 @@
-[{{ report_status }}] (host: {{ report_host }}) {{ report_reason }}
+  [{{ report_status }}] {{ report_reason }}
 {% if report_recommendations is defined and report_recommendations %}
 {% for recommendation in report_recommendations %}
   - RECOMMENDATION: {{ recommendation }}


### PR DESCRIPTION
These markers are used to identify individual entries in the report.
This way, ansible will just overwrite these entries, and not keep
appending new entries on the report.