### PR TITLE
Report changes in report

### DIFF
--- a/tasks/reportentry.yml
+++ b/tasks/reportentry.yml
@@ -6,6 +6,5 @@
     path: '{{ helper_report_path }}'
     content: "{{ lookup('template', 'templates/report-template-txt.j2') }}"
   delegate_to: localhost
-  changed_when: false
   tags:
     - common


### PR DESCRIPTION
This removes the "change" overwrite we had for report entries. This
way, every time an entry changes in the report, ansible will output
that.