### PR TITLE
Check that the certmonger user service has been enabled

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,4 +1,54 @@
 ---
+- name: prepare
+  hosts: all
+  tasks:
+    - name: Ensure EPEL is installed
+      package:
+        name: epel-release
+        state: present
+
+    - name: Ensure ruby is installed (needed by hiera)
+      package:
+        name: ruby
+        state: present
+
+    - name: Ensure hiera is installed
+      package:
+        name: hiera
+        state: present
+
+    - name: Create /etc/puppet directory
+      file:
+        path: /etc/puppet
+        state: directory
+        mode: 0755
+
+    - name: Create /etc/puppet/hieradata directory
+      file:
+        path: /etc/puppet/hieradata
+        state: directory
+        mode: 0755
+
+    - name: Create hiera config file
+      copy:
+        dest: "/etc/puppet/hiera.yaml"
+        content: |
+          ---
+          :backends:
+            - json
+          :json:
+            :datadir: /etc/puppet/hieradata
+          :hierarchy:
+            - all_nodes
+
+    - name: Create hiera file
+      copy:
+        dest: "/etc/puppet/hieradata/all_nodes.json"
+        content: |
+          {
+            "certmonger_user_enabled": true
+          }
+
 - name: Converge
   hosts: all
   roles:

--- a/tasks/overcloud.yml
+++ b/tasks/overcloud.yml
@@ -1,4 +1,35 @@
 ---
+# Check for certmonger user service
+- name: Check if the certmonger user service has been enabled
+  command: hiera -c /etc/puppet/hiera.yaml certmonger_user_enabled
+  become: true
+  changed_when: false
+  register: certmonger_user_enabled
+
+- name: Set facts for certmonger user service not enabled
+  set_fact:
+    certmonger_user_service_status: '{{ helper_status_error }}'
+    certmonger_user_service_reason: 'The certmonger user service is not enabled for this role'
+    certmonger_user_service_recommendations:
+      - "Please add the 'OS::TripleO::Services::CertmongerUser' service to all of your TripleO roles."
+  when: certmonger_user_enabled.stdout != "true"
+
+- name: Set facts for all certificates in monitoring status
+  set_fact:
+    certmonger_user_service_status: '{{ helper_status_ok }}'
+    certmonger_user_service_reason: 'This role contains the certmonger user service'
+    certmonger_user_service_recommendations: null
+  when: certmonger_user_enabled.stdout == "true"
+
+- name: Report status of the certificates
+  import_tasks: reportentry.yml
+  vars:
+    report_check: "Certmonger user service check"
+    report_status: '{{ certmonger_user_service_status }}'
+    report_host: '{{ ansible_hostname }}'
+    report_reason: '{{ certmonger_user_service_reason }}'
+    report_recommendations: '{{ certmonger_user_service_recommendations }}'
+
 # Certificate checks
 
 # Get all the certificates that certmonger is tracking. Given the


### PR DESCRIPTION
A common error is that folks don't enable the certmonger user service
in their roles. This check verifies that the role has been enabled by
that the host's hieradata.