### PR TITLE
Use MOLECULE_DISTRO for container image

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: instance
-    image: centos:7
+    image: ${MOLECULE_DISTRO:-"centos:7"}
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,6 +6,7 @@
       package:
         name: epel-release
         state: present
+      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
 
     - name: Ensure ruby is installed (needed by hiera)
       package:


### PR DESCRIPTION
we already set the MOLECULE_DISTRO env variable in our travis
configuration. This actually takes it into use... seems that before
we were only testing CentOS.